### PR TITLE
Add alert with link to 1.6.1 release announcement

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -58,8 +58,9 @@ enableRobotsTXT = true
     #no_minimize = true
 
     ## Set a site-wide notice for all visitors to all pages.
-#    alert = """
-#    """
+    alert = """
+#### Version 1.6.1 was just released! See our [Release Announcement](/posts/2026-01-05-first-release/)!
+    """
 
 ## Midnight can integrate custom shortcodes into the theme. For more
 ## about this, see https://bluestnight.com/docs/midnight/developers/


### PR DESCRIPTION
Found that in the config and thought it'd make sense at least for a while.

<img width="1088" height="439" alt="screenshot_2026-01-07_21-12-10" src="https://github.com/user-attachments/assets/1c5b1320-2552-4fe8-9ff6-7defa0278e93" />
